### PR TITLE
fix: handle 404 for terminated OCI instances to prevent ghost node ac…

### DIFF
--- a/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgent.java
+++ b/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgent.java
@@ -12,6 +12,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import com.oracle.bmc.core.model.Instance;
+import com.oracle.bmc.model.BmcException;
 import com.oracle.cloud.baremetal.jenkins.client.BaremetalCloudClient;
 import com.oracle.cloud.baremetal.jenkins.ssh.SshComputerLauncher;
 
@@ -263,6 +264,12 @@ public class BaremetalCloudAgent extends AbstractCloudSlave{
 			   currentState.equals(Instance.LifecycleState.Starting)){
 				return true;
 			}
+		} catch(BmcException e) {
+			if (e.getStatusCode() == 404) {
+				LOGGER.info("Instance " + instanceId + " no longer exists (404). Marking as not alive.");
+				return false;
+			}
+			throw new IOException(e);
 		} catch(Exception e) {
             throw new IOException(e);
 		}

--- a/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudInstanceMonitor.java
+++ b/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudInstanceMonitor.java
@@ -43,15 +43,21 @@ public class BaremetalCloudInstanceMonitor extends AsyncPeriodicWork {
 				try{
 					if(! agent.isAlive()){
 						LOGGER.info("Cloud Infrastructure instance is offline: " + agent.getDisplayName());
-						agent._terminate(listener);
-						LOGGER.info("Cloud Infrastructure instance is terminated: " + agent.getDisplayName());
+						try {
+							agent._terminate(listener);
+							LOGGER.info("Cloud Infrastructure instance is terminated: " + agent.getDisplayName());
+						} catch (Exception e) {
+							LOGGER.log(Level.WARNING, "Failed to terminate instance " + agent.getDisplayName()
+									+ ", proceeding with node removal. Error: " + e.getMessage());
+						}
 						removeNode(agent);
+						LOGGER.info("Removed node definition for: " + agent.getDisplayName());
 					}else{
 						LOGGER.info("Cloud Infrastructure instance is online: " + agent.getDisplayName());
 					}
 				} catch (IOException | InterruptedException | RuntimeException e){
-					LOGGER.info("Failed to terminate node : " + agent.getDisplayName());
-                                        LOGGER.info("ERROR : " + e.getMessage());
+					LOGGER.log(Level.WARNING, "Failed to check liveness of node: " + agent.getDisplayName()
+							+ ". Error: " + e.getMessage());
 				}
 			}
 		}

--- a/src/test/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudInstanceMonitorUnitTest.java
+++ b/src/test/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudInstanceMonitorUnitTest.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import com.oracle.bmc.core.model.Instance;
+import com.oracle.bmc.model.BmcException;
 import com.oracle.cloud.baremetal.jenkins.client.BaremetalCloudClient;
 
 import hudson.model.Node;
@@ -80,5 +81,40 @@ public class BaremetalCloudInstanceMonitorUnitTest {
         TestBaremetalCloudInstanceMonitor monitor = new TestBaremetalCloudInstanceMonitor(agent);
         monitor.execute(null);
         Assert.assertFalse(monitor.removed);
+    }
+
+    @Test
+    public void testExecuteInstanceNotFound404() throws Exception {
+        final BaremetalCloudClient client = mockery.mock(BaremetalCloudClient.class);
+        mockery.checking(new Expectations() {{
+            oneOf(client).getInstanceState("in");
+            will(throwException(new BmcException(404, "NotAuthorizedOrNotFound",
+                    "instance not found", "opc-request-id")));
+        }});
+        TestBaremetalCloudAgent agent = new TestBaremetalCloudAgent.Builder()
+                .instanceId("in")
+                .cloud(new TestBaremetalCloud.Builder().client(client).clock(new TestClock()).build())
+                .build();
+        TestBaremetalCloudInstanceMonitor monitor = new TestBaremetalCloudInstanceMonitor(agent);
+        monitor.execute(null);
+        Assert.assertTrue("Node should be removed when instance returns 404", monitor.removed);
+    }
+
+    @Test
+    public void testExecuteTerminateFailsNodeStillRemoved() throws Exception {
+        final BaremetalCloudClient client = mockery.mock(BaremetalCloudClient.class);
+        mockery.checking(new Expectations() {{
+            oneOf(client).getInstanceState("in"); will(returnValue(Instance.LifecycleState.Terminated));
+            oneOf(client).terminateInstance("in");
+            will(throwException(new BmcException(404, "NotAuthorizedOrNotFound",
+                    "instance not found", "opc-request-id")));
+        }});
+        TestBaremetalCloudAgent agent = new TestBaremetalCloudAgent.Builder()
+                .instanceId("in")
+                .cloud(new TestBaremetalCloud.Builder().client(client).clock(new TestClock()).build())
+                .build();
+        TestBaremetalCloudInstanceMonitor monitor = new TestBaremetalCloudInstanceMonitor(agent);
+        monitor.execute(null);
+        Assert.assertTrue("Node should be removed even when terminate fails", monitor.removed);
     }
 }

--- a/src/test/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudInstanceMonitorUnitTest.java
+++ b/src/test/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudInstanceMonitorUnitTest.java
@@ -90,6 +90,9 @@ public class BaremetalCloudInstanceMonitorUnitTest {
             oneOf(client).getInstanceState("in");
             will(throwException(new BmcException(404, "NotAuthorizedOrNotFound",
                     "instance not found", "opc-request-id")));
+            oneOf(client).terminateInstance("in");
+            will(throwException(new BmcException(404, "NotAuthorizedOrNotFound",
+                    "instance not found", "opc-request-id")));
         }});
         TestBaremetalCloudAgent agent = new TestBaremetalCloudAgent.Builder()
                 .instanceId("in")


### PR DESCRIPTION
## Summary

- **`BaremetalCloudAgent.isAlive()`**: When OCI returns 404 (instance no longer exists), the method now returns `false` instead of throwing an `IOException`. Other error codes (401, 500, network errors) still throw to avoid falsely declaring an instance dead during transient failures.
- **`BaremetalCloudInstanceMonitor.execute()`**: `_terminate()` is now wrapped in its own try-catch so that `removeNode()` always runs when `isAlive()` returns `false`, even if termination fails (e.g. instance already gone).
- Added two unit tests covering the 404 and terminate-failure scenarios.

## Problem

When an OCI compute instance is terminated externally or no longer exists, `getInstanceState()` throws a `BmcException` with HTTP 404. The `isAlive()` method catches this as a generic `Exception` and re-throws it as `IOException`, which prevents the instance monitor from identifying the node as dead.

In the monitor's `execute()` loop, this `IOException` is caught by the outer handler, which logs the error and moves on — `removeNode()` is never reached. Even if `isAlive()` correctly returned `false`, a secondary issue exists: `_terminate()` also fails on 404 (via `recycleCloudResources` → `terminateInstance`), and since `_terminate()` and `removeNode()` are sequential, the exception from `_terminate()` skips `removeNode()`.

The result is that ghost node definitions (`$JENKINS_HOME/nodes/oci-compute-*`) accumulate permanently across Jenkins restarts. In a production incident, **Hundreds ghost nodes** accumulated over time, causing crash loops on restart as Jenkins attempted to manage hundreds of non-existent instances simultaneously.

## Root Cause Trace

### Bug 1 — `isAlive()` throws on 404 instead of returning `false`

```
BaremetalCloudInstanceMonitor.execute()
  → agent.isAlive()
    → client.getInstanceState(instanceId)
      → OCI API returns 404 (BmcException)
    → catch(Exception e) { throw new IOException(e); }   ← wraps 404 as IOException
  → outer catch (IOException e) { log("Failed to terminate node") }
  → removeNode() is NEVER reached
  → node stays on disk → reloaded on next restart
```

`isAlive()` treats a 404 the same as a network error or server error. But 404 is a **definitive answer** — the instance does not exist. It should return `false` (not alive), not throw.

### Bug 2 — `_terminate()` failure prevents `removeNode()`

Even if Bug 1 were fixed so that `isAlive()` returned `false` for 404:

```
BaremetalCloudInstanceMonitor.execute()
  → agent.isAlive() returns false                         ← fixed by Bug 1 fix
  → agent._terminate(listener)
    → cloud.recycleCloudResources(instanceId)
      → terminateInstance(instanceId) → OCI 404 → throws
      → LinearRetry: 3 retries × 30s delay → all fail
    → throws IOException                                  ← propagates up
  → removeNode(agent)                                     ← SKIPPED (exception jumped past it)
  → outer catch logs error
  → node stays on disk
```

`_terminate()` and `removeNode()` are sequential in the same try block. If `_terminate()` throws, execution jumps to the outer catch, and `removeNode()` is never called.

Note: Jenkins core's `AbstractCloudSlave.terminate()` (no underscore) wraps `_terminate()` in a try/finally with `removeNode()` in the finally block. But the **monitor calls `_terminate()` directly** (underscore version), bypassing that safety net.

## The Fix

### Fix 1 — `BaremetalCloudAgent.isAlive()` (line 267-272)

```java
// BEFORE: all exceptions treated the same
catch(Exception e) {
    throw new IOException(e);
}

// AFTER: 404 returns false, other errors still throw
catch(BmcException e) {
    if (e.getStatusCode() == 404) {
        LOGGER.info("Instance " + instanceId + " no longer exists (404). Marking as not alive.");
        return false;
    }
    throw new IOException(e);
} catch(Exception e) {
    throw new IOException(e);
}
```

**Why this is safe**: Only 404 returns `false`. Auth errors (401), server errors (500), and network issues still throw — we don't want to falsely mark an instance as dead during a transient OCI outage.

### Fix 2 — `BaremetalCloudInstanceMonitor.execute()` (line 46-54)

```java
// BEFORE: _terminate() and removeNode() in sequence — exception skips removeNode()
agent._terminate(listener);
LOGGER.info("Cloud Infrastructure instance is terminated: " + agent.getDisplayName());
removeNode(agent);

// AFTER: _terminate() wrapped in its own try-catch — removeNode() always runs
try {
    agent._terminate(listener);
    LOGGER.info("Cloud Infrastructure instance is terminated: " + agent.getDisplayName());
} catch (Exception e) {
    LOGGER.log(Level.WARNING, "Failed to terminate instance " + agent.getDisplayName()
            + ", proceeding with node removal. Error: " + e.getMessage());
}
removeNode(agent);
LOGGER.info("Removed node definition for: " + agent.getDisplayName());
```

**Why this is safe**: `removeNode()` only runs when `isAlive()` returned `false` — meaning the instance is confirmed to not be in Running/Provisioning/Starting state. Removing a dead node definition is always correct. This matches the pattern Jenkins core uses in `AbstractCloudSlave.terminate()` (try/finally).

## Scenarios Verified

| Scenario | `isAlive()` | `_terminate()` | `removeNode()` | Correct? |
|---|---|---|---|---|
| Instance running | `true` | not called | No | Yes |
| Instance stopped | `false` | succeeds | Yes | Yes |
| Instance terminated | `false` | may throw 404 | **Yes (Fix 2)** | Yes |
| Instance gone (404) | **`false` (Fix 1)** | throws 404 | **Yes (Fix 2)** | Yes |
| OCI 500 error | throws | not reached | No | Yes (safe) |
| OCI auth error (401) | throws | not reached | No | Yes (safe) |
| Cloud config missing | throws IllegalState | not reached | No | Yes (safe) |

## Test Plan

- [x] `testExecuteInstanceNotFound404` — verifies node removal when `getInstanceState()` returns 404
- [x] `testExecuteTerminateFailsNodeStillRemoved` — verifies node removal when instance is in `Terminated` state and `terminateInstance()` throws 404
- [x] Existing tests (`testExecuteAlive`, `testExecuteNotAlive`, `testExecuteError`) remain unchanged
- [x] `mvn clean compile` passes successfully
